### PR TITLE
Fix setFloatValueInLoop function call to use 'floats' instead of 'integers'

### DIFF
--- a/lib/helpers/entity.ts
+++ b/lib/helpers/entity.ts
@@ -230,7 +230,7 @@ export const setEntityVariableValues = <T extends ModelEntity>(
 
     setEnumValueInLoop(partial, enums, variable);
 
-    setFloatValueInLoop(partial, integers, variable);
+    setFloatValueInLoop(partial, floats, variable);
 
     setIntegerValueInLoop(partial, integers, variable);
 


### PR DESCRIPTION
## Changes
- Fixed an issue where float values were not correctly converted in entity variable values.